### PR TITLE
Js add shared to folders

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,4 +30,14 @@ class User < ApplicationRecord
     user_folders.create(folder_id: folder.id, permissions: 0)
     folder
   end
+
+  def share_folder(user, folder)
+    if folder.owner == self
+      user.user_folders.create(folder_id: folder.id, user_id: user.id, permissions: 1)
+    end
+  end
+
+  def shared_with_me
+    folders.where(user_folders: { permissions: 1 })
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,10 @@ class User < ApplicationRecord
     folder
   end
 
+  def my_folders
+    folders.where(user_folders: { permissions: 0})
+  end
+
   def share_folder(user, folder)
     if folder.owner == self
       user.user_folders.create(folder_id: folder.id, user_id: user.id, permissions: 1)

--- a/app/views/dashboard/_user_dashboard.html.erb
+++ b/app/views/dashboard/_user_dashboard.html.erb
@@ -18,4 +18,9 @@
   <%= link_to "Root", root_folder_path %>
   <br>
   <%= link_to "New Folder", new_folder_path %>
+
+  <h1>Shared with me</h1>
+  <% current_user.shared_with_me.each do |folder| %>
+    <%= link_to "#{folder.name} / ", current_folder_path(folder.id) %>
+  <% end %>
 </div>

--- a/app/views/dashboard/_user_dashboard.html.erb
+++ b/app/views/dashboard/_user_dashboard.html.erb
@@ -18,9 +18,5 @@
   <%= link_to "Root", root_folder_path %>
   <br>
   <%= link_to "New Folder", new_folder_path %>
-
-  <h1>Shared with me</h1>
-  <% current_user.shared_with_me.each do |folder| %>
-    <%= link_to "#{folder.name} / ", current_folder_path(folder.id) %>
-  <% end %>
+  
 </div>


### PR DESCRIPTION
users now have a shared folder method

```joey.share_folder(matt, FOLDER)```

user has methods to retrieve folders that they own and folders that are shared with them. the view can call ```current_user.shared_with_me``` to see a list of shared folders. They can then have access to all folders and files that branch off of that folder. (so if you share your root folder, you essentially share everything you have). I'm pretty sure this makes sense from a design standpoint. if not, we can figure out a solution.

also added ```USER.my_folders``` to retrieve only folders that a user owns.